### PR TITLE
Remove download strategies deprecation warnings

### DIFF
--- a/custom_download_strategy.rb
+++ b/custom_download_strategy.rb
@@ -9,8 +9,6 @@ require "download_strategy"
 # distribution.  (It will work for public buckets as well.)
 class S3DownloadStrategy < CurlDownloadStrategy
   def initialize(url, name, version, **meta)
-    odeprecated("S3DownloadStrategy",
-      "maintaining S3DownloadStrategy in your own formula or tap")
     super
   end
 
@@ -51,8 +49,6 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   require "utils/github"
 
   def initialize(url, name, version, **meta)
-    odeprecated("GitHubPrivateRepositoryDownloadStrategy",
-      "maintaining GitHubPrivateRepositoryDownloadStrategy in your own formula or tap")
     super
     parse_url_pattern
     set_github_token
@@ -105,8 +101,6 @@ end
 # environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
 class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
   def initialize(url, name, version, **meta)
-    odeprecated("GitHubPrivateRepositoryReleaseDownloadStrategy",
-      "maintaining GitHubPrivateRepositoryReleaseDownloadStrategy in your own formula or tap")
     super
   end
 
@@ -161,8 +155,6 @@ end
 #     ...
 class ScpDownloadStrategy < AbstractFileDownloadStrategy
   def initialize(url, name, version, **meta)
-    odeprecated("ScpDownloadStrategy",
-      "maintaining ScpDownloadStrategy in your own formula or tap")
     super
     parse_url_pattern
   end
@@ -228,20 +220,12 @@ class DownloadStrategyDetector
       def detect_from_symbol(symbol)
         case symbol
         when :github_private_repo
-          odeprecated(":github_private_repo",
-            "maintaining GitHubPrivateRepositoryDownloadStrategy in your own formula or tap")
           GitHubPrivateRepositoryDownloadStrategy
         when :github_private_release
-          odeprecated(":github_private_repo",
-            "maintaining GitHubPrivateRepositoryReleaseDownloadStrategy in your own formula or tap")
           GitHubPrivateRepositoryReleaseDownloadStrategy
         when :s3
-          odeprecated(":s3",
-            "maintaining S3DownloadStrategy in your own formula or tap")
           S3DownloadStrategy
         when :scp
-          odeprecated(":scp",
-            "maintaining ScpDownloadStrategy in your own formula or tap")
           ScpDownloadStrategy
         else
           super(symbol)


### PR DESCRIPTION
These download strategies were originally supported in homebrew itself (see https://github.com/Homebrew/brew/pull/1763), but then they got first deprecated (see https://github.com/Homebrew/brew/pull/5112) with warning that Formulas which need these strategies should maintain their own copy, rationale being that no core formula use these strategies e.g. to download artifacts from private GitHub repos; finally this code was removed upstream. We copied last version of download strategies code (see https://github.com/giantswarm/homebrew-giantswarm-internal/pull/1), but included deprecation warnings as well, which results in noise (see https://github.com/giantswarm/giantswarm/issues/6007).