### PR TITLE
Fix errors, remove outdated/unused code, update API calls

### DIFF
--- a/custom_download_strategy.rb
+++ b/custom_download_strategy.rb
@@ -1,47 +1,12 @@
 require "download_strategy"
 
-# S3DownloadStrategy downloads tarballs from AWS S3.
-# To use it, add `:using => :s3` to the URL section of your
-# formula.  This download strategy uses AWS access tokens (in the
-# environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)
-# to sign the request.  This strategy is good in a corporate setting,
-# because it lets you use a private S3 bucket as a repo for internal
-# distribution.  (It will work for public buckets as well.)
-class S3DownloadStrategy < CurlDownloadStrategy
-  def initialize(url, name, version, **meta)
-    super
-  end
-
-  def _fetch(url:, resolved_url:)
-    if url !~ %r{^https?://([^.].*)\.s3\.amazonaws\.com/(.+)$} &&
-       url !~ %r{^s3://([^.].*?)/(.+)$}
-      raise "Bad S3 URL: " + url
-    end
-
-    bucket = Regexp.last_match(1)
-    key = Regexp.last_match(2)
-
-    ENV["AWS_ACCESS_KEY_ID"] = ENV["HOMEBREW_AWS_ACCESS_KEY_ID"]
-    ENV["AWS_SECRET_ACCESS_KEY"] = ENV["HOMEBREW_AWS_SECRET_ACCESS_KEY"]
-
-    begin
-      signer = Aws::S3::Presigner.new
-      s3url = signer.presigned_url :get_object, bucket: bucket, key: key
-    rescue Aws::Sigv4::Errors::MissingCredentialsError
-      ohai "AWS credentials missing, trying public URL instead."
-      s3url = url
-    end
-
-    curl_download s3url, to: temporary_path
-  end
-end
 
 # GitHubPrivateRepositoryDownloadStrategy downloads contents from GitHub
 # Private Repository. To use it, add
 # `:using => :github_private_repo` to the URL section of
 # your formula. This download strategy uses GitHub access tokens (in the
 # environment variables `HOMEBREW_GITHUB_API_TOKEN`) to sign the request.  This
-# strategy is suitable for corporate use just like S3DownloadStrategy, because
+# strategy is suitable for corporate use, because
 # it lets you use a private GitHub repository for internal distribution.  It
 # works with public one, but in that case simply use CurlDownloadStrategy.
 class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
@@ -139,57 +104,7 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   def fetch_release_metadata
     release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
-    GitHub.open_api(release_url)
-  end
-end
-
-# ScpDownloadStrategy downloads files using ssh via scp. To use it, add
-# `:using => :scp` to the URL section of your formula or
-# provide a URL starting with scp://. This strategy uses ssh credentials for
-# authentication. If a public/private keypair is configured, it will not
-# prompt for a password.
-#
-# @example
-#   class Abc < Formula
-#     url "scp://example.com/src/abc.1.0.tar.gz"
-#     ...
-class ScpDownloadStrategy < AbstractFileDownloadStrategy
-  def initialize(url, name, version, **meta)
-    super
-    parse_url_pattern
-  end
-
-  def parse_url_pattern
-    url_pattern = %r{scp://([^@]+@)?([^@:/]+)(:\d+)?/(\S+)}
-    if @url !~ url_pattern
-      raise ScpDownloadStrategyError, "Invalid URL for scp: #{@url}"
-    end
-
-    _, @user, @host, @port, @path = *@url.match(url_pattern)
-  end
-
-  def fetch
-    ohai "Downloading #{@url}"
-
-    if cached_location.exist?
-      puts "Already downloaded: #{cached_location}"
-    else
-      system_command! "scp", args: [scp_source, temporary_path.to_s]
-      ignore_interrupts { temporary_path.rename(cached_location) }
-    end
-  end
-
-  def clear_cache
-    super
-    rm_rf(temporary_path)
-  end
-
-  private
-
-  def scp_source
-    path_prefix = "/" unless @path.start_with?("~")
-    port_arg = "-P #{@port[1..-1]} " if @port
-    "#{port_arg}#{@user}#{@host}:#{path_prefix}#{@path}"
+    GitHub::API.open_rest(release_url)
   end
 end
 
@@ -198,23 +113,11 @@ class DownloadStrategyDetector
     module Compat
       def detect(url, using = nil)
         strategy = super
-        require_aws_sdk if strategy == S3DownloadStrategy
         strategy
       end
 
       def detect_from_url(url)
-        case url
-        when %r{^s3://}
-          odeprecated("s3://",
-            "maintaining S3DownloadStrategy in your own formula or tap")
-          S3DownloadStrategy
-        when %r{^scp://}
-          odeprecated("scp://",
-            "maintaining ScpDownloadStrategy in your own formula or tap")
-          ScpDownloadStrategy
-        else
-          super(url)
-        end
+        super(url)
       end
 
       def detect_from_symbol(symbol)
@@ -223,10 +126,6 @@ class DownloadStrategyDetector
           GitHubPrivateRepositoryDownloadStrategy
         when :github_private_release
           GitHubPrivateRepositoryReleaseDownloadStrategy
-        when :s3
-          S3DownloadStrategy
-        when :scp
-          ScpDownloadStrategy
         else
           super(symbol)
         end


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/16580 in parts, to allow installing/upgrading opsctl and devctl via homebrew again.